### PR TITLE
query by package name and option to keep lower package classes (colored differently), and other fixes

### DIFF
--- a/ada-ui/src/app/graph/graph.component.ts
+++ b/ada-ui/src/app/graph/graph.component.ts
@@ -35,6 +35,7 @@ export class GraphComponent implements OnInit {
   private metricNameConverter = new MetricNameConverter();
 
   private previousNodesQuery = [];
+  private coloredNodes = false;
 
   constructor(queryService: QueryService) { 
     if (queryService.receivedQueryEvent$) {
@@ -121,6 +122,8 @@ export class GraphComponent implements OnInit {
     let nodesMainPackage = this.cy.nodes(`[mainPackage = "${queryText}"]`);
     let higherPackages = [];
     let nodesHigherPackages = [];
+
+    this.coloredNodes = seePackageHigherClasses;
 
     this.cy.batch(function() {
       this.cy.nodes().forEach(function(node) {
@@ -918,6 +921,15 @@ export class GraphComponent implements OnInit {
     this.cy.on('unselect', '*', function(evt){
       self.emitElementUnelectedEvent(evt.target);
       self.unhighlightElementNeighbourhood(evt.target);
+
+      if (self.coloredNodes) {
+        self.cy.batch(function() {
+          self.cy.nodes().forEach(function(node) {
+            node.removeStyle('background-color');
+          })
+        }.bind(this));
+        self.coloredNodes = false;
+      }
     });
   }
 

--- a/ada-ui/src/app/query-form/query-form.component.css
+++ b/ada-ui/src/app/query-form/query-form.component.css
@@ -14,4 +14,5 @@
 
 .query-button {
     float: right;
+    margin-top: 1em;
 }

--- a/ada-ui/src/app/query-form/query-form.component.html
+++ b/ada-ui/src/app/query-form/query-form.component.html
@@ -16,8 +16,9 @@
 						 [(ngModel)]="queryText"
 						 required #query="ngModel">
 		</mat-form-field>
-		<mat-checkbox [disabled]="!isPackageQuery()" [(ngModel)]="seePackageHigherClasses" name="seePackageHigherClassesCheckbox">See classes from higher packages</mat-checkbox>
+		<mat-checkbox [disabled]="!isPackageQuery()" [(ngModel)]="seePackageHigherClasses" name="seePackageHigherClassesCheckbox">See classes from lower packages</mat-checkbox>
 		<button type="submit" [disabled]="!queryForm.form.valid" mat-raised-button color="primary" class="query-button">Go</button>
+		<p *ngIf="queryMessage">{{queryMessage}}</p>
 	</form>
 </div>
 

--- a/ada-ui/src/app/query-form/query-form.component.html
+++ b/ada-ui/src/app/query-form/query-form.component.html
@@ -16,6 +16,7 @@
 						 [(ngModel)]="queryText"
 						 required #query="ngModel">
 		</mat-form-field>
+		<mat-checkbox [disabled]="!isPackageQuery()" [(ngModel)]="seePackageHigherClasses" name="seePackageHigherClassesCheckbox">See classes from higher packages</mat-checkbox>
 		<button type="submit" [disabled]="!queryForm.form.valid" mat-raised-button color="primary" class="query-button">Go</button>
 	</form>
 </div>

--- a/ada-ui/src/app/query-form/query-form.component.ts
+++ b/ada-ui/src/app/query-form/query-form.component.ts
@@ -12,8 +12,17 @@ export class QueryFormComponent implements OnInit {
   private queryTypes = ['Class', 'Package'];
   private queryText: string;
   private seePackageHigherClasses: boolean;
+  private queryMessage;
 
-  constructor(private queryService: QueryService) { }
+  constructor(private queryService: QueryService) { 
+    if (this.queryService.receivedQueryMessageEvent$) {
+      this.queryService.receivedQueryMessageEvent$.subscribe(
+        queryMessage => {
+          this.processMessage(queryMessage);
+        }
+      )
+    }
+  }
 
   ngOnInit() {
     this.seePackageHigherClasses = false;
@@ -26,6 +35,10 @@ export class QueryFormComponent implements OnInit {
       }
     }
     return false;
+  }
+
+  processMessage(queryMessage: string) {
+    this.queryMessage = queryMessage;
   }
 
   onSubmit() {

--- a/ada-ui/src/app/query-form/query-form.component.ts
+++ b/ada-ui/src/app/query-form/query-form.component.ts
@@ -11,14 +11,25 @@ export class QueryFormComponent implements OnInit {
   private selectedQueryType: string;
   private queryTypes = ['Class', 'Package'];
   private queryText: string;
+  private seePackageHigherClasses: boolean;
 
   constructor(private queryService: QueryService) { }
 
   ngOnInit() {
+    this.seePackageHigherClasses = false;
+  }
+
+  isPackageQuery(): boolean {
+    if (this.selectedQueryType) {
+      if(this.selectedQueryType.toLowerCase() === 'package') {
+        return true;
+      }
+    }
+    return false;
   }
 
   onSubmit() {
-    this.queryService.sendQueryToGraph([this.selectedQueryType.toLowerCase(), this.queryText.trim()]);
+    this.queryService.sendQueryToGraph([this.selectedQueryType.toLowerCase(), this.queryText.trim(), this.seePackageHigherClasses]);
   }
 
 }

--- a/ada-ui/src/app/query.service.ts
+++ b/ada-ui/src/app/query.service.ts
@@ -6,13 +6,13 @@ import { Subject } from 'rxjs';
 })
 export class QueryService {
 
-  private receivedQuery = new Subject<string[]>();
+  private receivedQuery = new Subject<any>();
 
   receivedQueryEvent$ = this.receivedQuery.asObservable();
 
   constructor() { }
 
-  sendQueryToGraph(query: string[]) {
+  sendQueryToGraph(query: (string|boolean)[]) {
     this.receivedQuery.next(query);
   }
 }

--- a/ada-ui/src/app/query.service.ts
+++ b/ada-ui/src/app/query.service.ts
@@ -7,12 +7,18 @@ import { Subject } from 'rxjs';
 export class QueryService {
 
   private receivedQuery = new Subject<any>();
+  private receivedQueryMessage = new Subject<string>();
 
   receivedQueryEvent$ = this.receivedQuery.asObservable();
+  receivedQueryMessageEvent$ = this.receivedQueryMessage.asObservable();
 
   constructor() { }
 
   sendQueryToGraph(query: (string|boolean)[]) {
     this.receivedQuery.next(query);
+  }
+
+  sendQueryMessageToQueryForm(message: string) {
+    this.receivedQueryMessage.next(message);
   }
 }


### PR DESCRIPTION
query by package name and option to keep lower package classes (colored differently), and other fixes